### PR TITLE
fix for existing script uncaught error

### DIFF
--- a/src/front/scripts/index.js
+++ b/src/front/scripts/index.js
@@ -365,47 +365,45 @@ $(document).ready(function () {
       $(this).next('tr[data-pl-detail-row]').toggle();
   });
 
-   // Controlling Block/structure for activating the hopscotch framework's API calls below used to start a tour
-  // Reference framework at http://linkedin.github.io/hopscotch/
-      if (document.URL.indexOf('tours.html') > -1) {
-    // Define the tour!
-    /* jshint ignore:start */
-        var tour = {
-         id: 'hopscotch-example',
-         steps: [{
-            title: 'Hopscotch Tour Example',
-            content: 'This is the header of my page.',
-            target: 'tour',
-            placement: 'top'
-            },
-            {
-            title: 'Purpose',
-            content: 'Example of tour.',
-            target: 'purpose',
-            placement: 'bottom'
-            }, {
-            title: 'Navigation',
-            content: 'Foundation, Components, Patterns describe how best to use the CBP Theme.',
-            target: 'sidebar',
-            placement: 'right'
-            }
-        ],
-            showPrevButton: true
-        };
+  // Define the tour!
+  /* jshint ignore:start */
+  var tour = {
+      id: 'hopscotch-example',
+      steps: [{
+              title: 'Hopscotch Tour Example',
+              content: 'This is the header of my page.',
+              target: 'tour',
+              placement: 'top'
+          },
+          {
+              title: 'Purpose',
+              content: 'Example of tour.',
+              target: 'purpose',
+              placement: 'bottom'
+          }, {
+              title: 'Navigation',
+              content: 'Foundation, Components, Patterns describe how best to use the CBP Theme.',
+              target: 'sidebar',
+              placement: 'right'
+          }
 
-        var calloutMgr = hopscotch.getCalloutManager();
-          calloutMgr.createCallout({
-            id: 'attach-icon',
-            target: 'callout-button',
-            placement: 'right',
-            title: 'Callout Example',
-            content: 'For simple explanations.'
-        });
+      ],
+      showPrevButton: true
+  };
+  var calloutMgr = hopscotch.getCalloutManager();
+  
+  if (document.URL.indexOf('tours.html') > -1) {
+      // Start the tour!
+      hopscotch.startTour(tour);
 
- // Start the tour!
-        hopscotch.startTour(tour);
-}
-// End of the controlling Block/structure for activating the hopscotch framework's API calls
+      calloutMgr.createCallout({
+        id: 'attach-icon',
+        target: 'callout-button',
+        placement: 'right',
+        title: 'Callout Example',
+        content: 'For simple explanations.'
+    });
+  }  
 
   /* jshint ignore:end */
   /* google analytics download tracking */

--- a/src/front/scripts/index.js
+++ b/src/front/scripts/index.js
@@ -365,45 +365,48 @@ $(document).ready(function () {
       $(this).next('tr[data-pl-detail-row]').toggle();
   });
 
-  // Define the tour!
-  /* jshint ignore:start */
-  var tour = {
-      id: 'hopscotch-example',
-      steps: [{
-              title: 'Hopscotch Tour Example',
-              content: 'This is the header of my page.',
-              target: 'tour',
-              placement: 'top'
-          },
-          {
-              title: 'Purpose',
-              content: 'Example of tour.',
-              target: 'purpose',
-              placement: 'bottom'
-          }, {
-              title: 'Navigation',
-              content: 'Foundation, Components, Patterns describe how best to use the CBP Theme.',
-              target: 'sidebar',
-              placement: 'right'
-          }
+   // Controlling Block/structure for activating the hopscotch framework's API calls below used to start a tour
+  // Reference framework at http://linkedin.github.io/hopscotch/
+      if (document.URL.indexOf('tours.html') > -1) {
+    // Define the tour!
+    /* jshint ignore:start */
+        var tour = {
+         id: 'hopscotch-example',
+         steps: [{
+            title: 'Hopscotch Tour Example',
+            content: 'This is the header of my page.',
+            target: 'tour',
+            placement: 'top'
+            },
+            {
+            title: 'Purpose',
+            content: 'Example of tour.',
+            target: 'purpose',
+            placement: 'bottom'
+            }, {
+            title: 'Navigation',
+            content: 'Foundation, Components, Patterns describe how best to use the CBP Theme.',
+            target: 'sidebar',
+            placement: 'right'
+            }
+        ],
+            showPrevButton: true
+        };
 
-      ],
-      showPrevButton: true
-  };
+        var calloutMgr = hopscotch.getCalloutManager();
+          calloutMgr.createCallout({
+            id: 'attach-icon',
+            target: 'callout-button',
+            placement: 'right',
+            title: 'Callout Example',
+            content: 'For simple explanations.'
+        });
 
-  // Start the tour!
-  if (document.URL.indexOf('tours.html') > -1) {
-      hopscotch.startTour(tour);
-  }
+ // Start the tour!
+        hopscotch.startTour(tour);
+}
+// End of the controlling Block/structure for activating the hopscotch framework's API calls
 
-  var calloutMgr = hopscotch.getCalloutManager();
-  calloutMgr.createCallout({
-      id: 'attach-icon',
-      target: 'callout-button',
-      placement: 'right',
-      title: 'Callout Example',
-      content: 'For simple explanations.'
-  });
   /* jshint ignore:end */
   /* google analytics download tracking */
 


### PR DESCRIPTION
#### What's this PR do?

Resolve an uncaught error

#### Where should the reviewer start?

Using developer tools for whatever browser chosen, can use the console option to see the current uncaught errors being produced from any page within the style guide (besides the tours page).  Next, look at the HTMLDocument error stemming from the 'src/generated/scripts/main.js' in regards to some Hopscotch Callouts.  This is fixed by using the existing if statement holding the startTour API call as a controlling block for all the function literal and the hopscotch calls being used only on https://us-cbp.github.io/cbp-style-guide/docs/patterns/tours.html.

#### How should this be manually tested?

First you can see that the errors occur everywhere except on https://us-cbp.github.io/cbp-style-guide/docs/patterns/tours.html, meaning the function literal as the value of the callback and the hopscotch callouts need to be activated along with the startTour API method.
 
#### Any background context you want to provide?

Just noticed this error when beginning research on the style guide build.

#### What are the relevant tickets?

n/a

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/24257663/56741969-e2f8c480-6741-11e9-8932-cd45b524c493.png)

#### Questions:
- Is there a blog post?

n/a

- Does the knowledge base need an update?

not sure
- Does this add new (Python) dependencies which need to be added to chef?

no
